### PR TITLE
Add package code to pypi.org release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update --yes \
 
 WORKDIR /app
 
-COPY ./flask_opensearch/ ./
+COPY ./flask_opensearch/ ./flask_opensearch/
 COPY ./tests ./
 COPY ./README.md ./
 COPY setup.py ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,13 @@
 FROM ubuntu:18.04
 
+RUN apt-get update --yes \
+    && apt-get install --yes software-properties-common \
+    && add-apt-repository --yes ppa:deadsnakes/ppa \
+    && apt-get update --yes \
+    && apt-get install --yes python3.6 python3.7 python3.8 python3.9 \
+    && apt install --yes python3-pip \
+    && pip3 install tox
+
 WORKDIR /app
 
 COPY ./flask_opensearch/ ./
@@ -9,13 +17,6 @@ COPY setup.py ./
 COPY setup.cfg ./
 COPY tox.ini ./
 
-RUN apt-get update --yes \
-    && apt-get install --yes software-properties-common \
-    && add-apt-repository --yes ppa:deadsnakes/ppa \
-    && apt-get update --yes \
-    && apt-get install --yes python3.6 python3.7 python3.8 python3.9 \
-    && apt install --yes python3-pip \
-    && pip3 install tox \
-    && pip3 install -e .
+RUN pip3 install -e .
 
 ENTRYPOINT ["tox"]

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     description='Flask extension for opensearch integration',
     long_description=read("README.md"),
     long_description_content_type="text/markdown",
-    py_modules=['flask_opensearch'],
+    packages=['flask_opensearch'],
     zip_safe=False,
     include_package_data=True,
     platforms='any',


### PR DESCRIPTION
A module is when we have the python file in the root of the repo. This worked in the Docker container because we copied the contents of the flask_opensearch directory into the root. However, it doesn't work in the release GitHub action because there is no flask_opensearch.py in the root of the repo. So the current version released to pypi.org contains no code.

Instead, what we need to use is packages (https://setuptools.pypa.io/en/latest/deprecated/distutils/examples.html?highlight=py_modules#pure-python-distribution-by-package). This ensures that `python build` can pick up the package.

Update the Dockerfile to match. Also move the apt requirement installation to the start to speed up development.