### PR TITLE
Flaskapp example

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -94,3 +94,6 @@ venv/
 */*.swp
 */*/*.swp
 */*/*/*.swp
+
+# Examples Directory
+examples/

--- a/examples/simple_app/.flake8
+++ b/examples/simple_app/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max_line_length = 120

--- a/examples/simple_app/Dockerfile
+++ b/examples/simple_app/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.9-slim
+
+COPY ./requirements.txt .
+
+RUN pip3 install -r requirements.txt
+
+WORKDIR /app
+
+COPY ./src .
+
+ENV FLASK_APP app
+
+EXPOSE 5000 5000
+
+CMD [ "python3", "-m", "flask", "run", "--host=0.0.0.0" ]

--- a/examples/simple_app/README.md
+++ b/examples/simple_app/README.md
@@ -14,6 +14,7 @@ An example flask app to demonstrate building and querying an index.
 - Start the app with `./scripts/run.sh`
 - Wait until you can see log output for the opensearch instance.
 - In another terminal, cd to `examples/simple_app`, then run `./scripts/load.sh`. You should see a progress bar indicating how much movie data has been written to opensearch.
+- Check that the REST endpoint for searching works with `curl "http://localhost:5000/movies?search=alien&count=3"`
 - When you are done, run `./scripts/stop.sh`, or change to the terminal that is running the docker compose services and press `CTRL+C`
 
 ### Windows

--- a/examples/simple_app/README.md
+++ b/examples/simple_app/README.md
@@ -1,0 +1,20 @@
+An example flask app to demonstrate building and querying an index.
+
+## Setup
+
+### Unix
+- Install Docker
+- In a terminal, change directories to `examples/simple_app` (the directory containing this README)
+- Make sure you can execute all files in `examples/simple_app/scripts`
+    ```
+    chmod +x ./scripts/run.sh
+    chmod +x ./scripts/load.sh
+    chmod +x ./scripts/stop.sh
+    ```
+- Start the app with `./scripts/run.sh`
+- Wait until you can see log output for the opensearch instance.
+- In another terminal, cd to `examples/simple_app`, then run `./scripts/load.sh`. You should see a progress bar indicating how much movie data has been written to opensearch.
+- When you are done, run `./scripts/stop.sh`, or change to the terminal that is running the docker compose services and press `CTRL+C`
+
+### Windows
+- TODO

--- a/examples/simple_app/docker-compose.example.yaml
+++ b/examples/simple_app/docker-compose.example.yaml
@@ -12,6 +12,7 @@ services:
     build: .
     volumes:
       - ./src:/app
+      - ./data:/data
     ports:
       - 5000:5000
     environment:

--- a/examples/simple_app/docker-compose.example.yaml
+++ b/examples/simple_app/docker-compose.example.yaml
@@ -11,8 +11,7 @@ services:
   example_flaskapp:
     build: .
     volumes:
-      - ./src:/app
-      - ./data:/data
+      ["./src:/app", "./data:/data"]
     ports:
       - 5000:5000
     environment:

--- a/examples/simple_app/docker-compose.example.yaml
+++ b/examples/simple_app/docker-compose.example.yaml
@@ -1,0 +1,22 @@
+version: "3.9"
+services:
+  opensearch:
+    image: opensearchproject/opensearch:1.0.0
+    ports:
+      - "9200:9200"
+      - "9600:9600"
+    environment:
+      - discovery.type=single-node
+
+  example_flaskapp:
+    build: .
+    volumes:
+      - ./src:/app
+    ports:
+      - 5000:5000
+    environment:
+      - OPENSEARCH_HOST=opensearch
+      - OPENSEARCH_USER=admin
+      - OPENSEARCH_PASSWORD=admin
+      - OPENSEARCH_PORT=9200
+      - PYTHONPATH=/app

--- a/examples/simple_app/requirements.txt
+++ b/examples/simple_app/requirements.txt
@@ -1,2 +1,3 @@
+alive-progress==2.4.1
 Flask==2.1.3
 Flask-Opensearch==1.0.2

--- a/examples/simple_app/requirements.txt
+++ b/examples/simple_app/requirements.txt
@@ -1,0 +1,2 @@
+Flask==2.1.3
+Flask-Opensearch==1.0.2

--- a/examples/simple_app/scripts/format.sh
+++ b/examples/simple_app/scripts/format.sh
@@ -1,0 +1,2 @@
+#! /bin/bash
+black --target-version py39 --line-length 120 ./src

--- a/examples/simple_app/scripts/lint.sh
+++ b/examples/simple_app/scripts/lint.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+flake8 ./src

--- a/examples/simple_app/scripts/load.sh
+++ b/examples/simple_app/scripts/load.sh
@@ -1,0 +1,2 @@
+#! /bin/bash
+docker compose -f docker-compose.example.yaml exec example_flaskapp flask load-opensearch

--- a/examples/simple_app/scripts/run.sh
+++ b/examples/simple_app/scripts/run.sh
@@ -1,0 +1,2 @@
+#! /bin/bash
+docker compose -f docker-compose.example.yaml up --build

--- a/examples/simple_app/scripts/stop.sh
+++ b/examples/simple_app/scripts/stop.sh
@@ -1,0 +1,2 @@
+#! /bin/bash
+docker compose -f docker-compose.example.yaml down

--- a/examples/simple_app/src/app.py
+++ b/examples/simple_app/src/app.py
@@ -1,0 +1,13 @@
+from flask import Flask
+
+
+app = Flask(__name__)
+
+
+@app.route("/")
+def hello_world():
+    return "<p>Hello, World!</p>"
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/examples/simple_app/src/app.py
+++ b/examples/simple_app/src/app.py
@@ -1,13 +1,67 @@
+import csv
+import os
+import time
+
+from alive_progress import alive_bar
 from flask import Flask
+from flask_opensearch import FlaskOpenSearch
+
 
 
 app = Flask(__name__)
+
+app.config["OPENSEARCH_HOST"] = os.environ["OPENSEARCH_HOST"]
+app.config["OPENSEARCH_USER"] = os.environ["OPENSEARCH_USER"]
+app.config["OPENSEARCH_PASSWORD"] = os.environ["OPENSEARCH_PASSWORD"]
+
+opensearch = FlaskOpenSearch(
+    app=app,
+    use_ssl=True,
+    verify_certs=False,
+    ssl_assert_hostname=False,
+    ssl_show_warn=False,
+)
 
 
 @app.route("/")
 def hello_world():
     return "<p>Hello, World!</p>"
 
+
+@app.cli.command("load-opensearch")
+def load_opensearch():
+    print("Load opensearch ...")
+    # create index
+    print("Creating movies_metadata index")
+    opensearch.indices.create(
+        "movies_metadata",
+        body={
+            "settings": {
+                "index": {
+                    "number_of_shards": 1,
+                }
+            }
+        },
+    )
+
+    # write data
+    print("Inserting documents into movies_metadata index")
+    with alive_bar(45466, dual_line=True, title="Loading Movies") as progress_bar:
+        progress_bar.text = "Loading movies ..."
+        with open("/data/movies_metadata.csv", "r") as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                try:
+                    opensearch.index(
+                        "movies_metadata",
+                        body=row,
+                        id=row["id"],
+                        refresh=True,
+                    )
+                except Exception as e:
+                    print(f"Error for movie id {row['id']}: {e}")
+                time.sleep(0.001)
+                progress_bar()
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/examples/simple_app/src/app.py
+++ b/examples/simple_app/src/app.py
@@ -1,19 +1,43 @@
 import csv
 import os
 import time
+from logging.config import dictConfig
 
+import opensearchpy
 from alive_progress import alive_bar
-from flask import Flask
+from flask import Flask, request, jsonify
 from flask_opensearch import FlaskOpenSearch
 
 
+# configure logging
+dictConfig(
+    {
+        "version": 1,
+        "formatters": {
+            "default": {
+                "format": "[%(asctime)s] %(levelname)s in %(module)s: %(message)s",
+            }
+        },
+        "handlers": {
+            "wsgi": {
+                "class": "logging.StreamHandler",
+                "stream": "ext://flask.logging.wsgi_errors_stream",
+                "formatter": "default",
+            }
+        },
+        "root": {"level": "INFO", "handlers": ["wsgi"]},
+    }
+)
 
+
+# initialize app and configure from environment variables
 app = Flask(__name__)
-
 app.config["OPENSEARCH_HOST"] = os.environ["OPENSEARCH_HOST"]
 app.config["OPENSEARCH_USER"] = os.environ["OPENSEARCH_USER"]
 app.config["OPENSEARCH_PASSWORD"] = os.environ["OPENSEARCH_PASSWORD"]
 
+
+# initialize opensearch extension
 opensearch = FlaskOpenSearch(
     app=app,
     use_ssl=True,
@@ -28,21 +52,42 @@ def hello_world():
     return "<p>Hello, World!</p>"
 
 
+@app.route("/movies")
+def list_movies():
+    search = request.args.get("search", "toy story")
+    count = int(request.args.get("count", 5))
+    count = min(count, 100)
+    return jsonify(_search_movies(search, count))
+
+
+def _search_movies(search, results=5):
+    response = opensearch.search(
+        body={
+            "size": results,
+            "query": {"multi_match": {"query": search, "fields": ["title", "original_title", "overview"]}},
+        }
+    )
+    return [x["_source"] for x in response["hits"]["hits"]]
+
+
 @app.cli.command("load-opensearch")
 def load_opensearch():
     print("Load opensearch ...")
     # create index
     print("Creating movies_metadata index")
-    opensearch.indices.create(
-        "movies_metadata",
-        body={
-            "settings": {
-                "index": {
-                    "number_of_shards": 1,
+    try:
+        opensearch.indices.create(
+            "movies_metadata",
+            body={
+                "settings": {
+                    "index": {
+                        "number_of_shards": 1,
+                    }
                 }
-            }
-        },
-    )
+            },
+        )
+    except opensearchpy.exceptions.RequestError as e:
+        print(f"Error creating movies_metadata index: {e}")
 
     # write data
     print("Inserting documents into movies_metadata index")
@@ -62,6 +107,7 @@ def load_opensearch():
                     print(f"Error for movie id {row['id']}: {e}")
                 time.sleep(0.001)
                 progress_bar()
+
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/examples/simple_app/src/app.py
+++ b/examples/simple_app/src/app.py
@@ -47,9 +47,9 @@ opensearch = FlaskOpenSearch(
 )
 
 
-@app.route("/")
-def hello_world():
-    return "<p>Hello, World!</p>"
+@app.route("/healthcheck")
+def healthcheck():
+    return "healthy"
 
 
 @app.route("/movies")


### PR DESCRIPTION
Issue addressed: https://github.com/galbwe/Flask-Opensearch/issues/10

The issue originally requested a web UI, so I will continue working on that. This MR provides incremental progress towards that goal.

Adds a minimal flask app that supports:
1. Loading a [movie dataset](https://www.kaggle.com/datasets/rounakbanik/the-movies-dataset?select=movies_metadata.csv) from kaggle into an opensearch instance running in docker.
2. Searching the movie data with a REST api endpoint.

To run the app follow these instructions (also in the README):

- In a terminal, change directories to `examples/simple_app` (the directory containing this README)
- Make sure you can execute all files in `examples/simple_app/scripts`
    ```
    chmod +x ./scripts/run.sh
    chmod +x ./scripts/load.sh
    chmod +x ./scripts/stop.sh
    ```
- Start the app with `./scripts/run.sh`
- Wait until you can see log output for the opensearch instance.
- In another terminal, cd to `examples/simple_app`, then run `./scripts/load.sh`. You should see a progress bar indicating how much movie data has been written to opensearch.
- Check that the REST endpoint for searching works with `curl "http://localhost:5000/movies?search=alien&count=3"`
- When you are done, run `./scripts/stop.sh`, or change to the terminal that is running the docker compose services and press `CTRL+C`

